### PR TITLE
Updates the Npgsql library and adds ExecuteType option

### DIFF
--- a/Frends.PostgreSQL.ExecuteQuery/CHANGELOG.md
+++ b/Frends.PostgreSQL.ExecuteQuery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.0] - 2024-12-11
+### Added
+- Added new option ExecuteType to be able to execute a none query with a select query.
+
+### Changed
+- Updated the Npgsql package to version 9.0.2
+
 ## [1.1.0] - 2024-08-23
 ### Changed
 - Updated the Newtonsoft.Json package to version 13.0.3 and the Npgsql package to version 8.0.3.

--- a/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery.Tests/ExecuteQueryTests.cs
+++ b/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery.Tests/ExecuteQueryTests.cs
@@ -11,16 +11,16 @@ namespace Frends.PostgreSQL.ExecuteQuery.Tests;
 public class ExecuteQueryTests
 {
 
-    /// <summary>
-    /// These test requires local postgres database, create it e.g. with
-    ///
-    ///  docker run -p 5432:5432 -e POSTGRES_PASSWORD=mysecretpassword -d postgres
-    ///
-    /// </summary>
+	/// <summary>
+	/// These test requires local postgres database, create it e.g. with
+	///
+	///  docker run -p 5432:5432 -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+	///
+	/// </summary>
 
-    private readonly string _connection = "Host=localhost;Database=postgres;Port=5432;User Id=postgres;Password=mysecretpassword;";
+	private readonly string _connection = "Host=localhost;Database=postgres;Port=5432;User Id=postgres;Password=mysecretpassword;";
 
-    private readonly Options _options = new()
+	private readonly Options _options = new()
     {
         CommandTimeoutSeconds = 10,
         SqlTransactionIsolationLevel = TransactionIsolationLevel.Default
@@ -65,14 +65,15 @@ public class ExecuteQueryTests
         {
             Query = "SELECT * FROM lista",
             Parameters = null,
-            ConnectionString = _connection
+            ConnectionString = _connection,
+			ExecuteType = ExecuteTypes.ExecuteReader
         };
 
         var result = await PostgreSQL.ExecuteQuery(input, _options, new CancellationToken());
 
-        Assert.AreEqual(1, (int)result.QueryResult[0]["id"]);
-        Assert.AreEqual(2, (int)result.QueryResult[1]["id"]);
-        Assert.AreEqual(3, (int)result.QueryResult[2]["id"]);
+        Assert.AreEqual(1, (int)result.Data[0]["id"]);
+        Assert.AreEqual(2, (int)result.Data[1]["id"]);
+        Assert.AreEqual(3, (int)result.Data[2]["id"]);
     }
 
     /// <summary>
@@ -90,7 +91,7 @@ public class ExecuteQueryTests
 
 
         var result = await PostgreSQL.ExecuteQuery(input, _options, new CancellationToken());
-        Assert.AreEqual(0, result.QueryResult.Count);
+        Assert.AreEqual(0, result.Data.Count);
     }
 
     /// <summary>
@@ -107,10 +108,37 @@ public class ExecuteQueryTests
         };
 
         var result = await PostgreSQL.ExecuteQuery(input, _options, new CancellationToken());
-        Assert.AreEqual(1, (int)result.QueryResult["AffectedRows"]);
+        Assert.AreEqual(1, result.RecordsAffected);
 
         input.Query = "SELECT * from lista WHERE id=5";
         result = await PostgreSQL.ExecuteQuery(input, _options, new CancellationToken());
-        Assert.AreEqual("Viides", (string)result.QueryResult[0]["selite"]);
+        Assert.AreEqual("Viides", (string)result.Data[0]["selite"]);
     }
+
+	/// <summary>
+	/// Test non-query operation with select.
+	/// </summary>
+	[Test]
+	public async Task TestInsertSelectQuery()
+	{
+		var input = new Input
+		{
+			Query = @"
+						INSERT INTO lista (Id, Selite)
+						SELECT 99, Selite
+						FROM lista WHERE Id = 1
+					",
+			Parameters = null,
+			ExecuteType = ExecuteTypes.NonQuery,
+			ConnectionString = _connection
+		};
+
+		var result = await PostgreSQL.ExecuteQuery(input, _options, new CancellationToken());
+		Assert.AreEqual(1, result.RecordsAffected);
+
+		input.Query = "SELECT * from lista WHERE id=99";
+		input.ExecuteType = ExecuteTypes.ExecuteReader;
+		result = await PostgreSQL.ExecuteQuery(input, _options, new CancellationToken());
+		Assert.AreEqual("Ensimmäinen", (string)result.Data[0]["selite"]);
+	}
 }

--- a/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Definitions/ExecuteTypes.cs
+++ b/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Definitions/ExecuteTypes.cs
@@ -1,0 +1,26 @@
+﻿namespace Frends.PostgreSQL.ExecuteQuery.Definitions;
+/// <summary>
+/// Execute types.
+/// </summary>
+public enum ExecuteTypes
+{
+	/// <summary>
+	/// ExecuteReader for SELECT-query and NonQuery for UPDATE, INSERT, or DELETE statements.
+	/// </summary>
+	Auto,
+
+	/// <summary>
+	/// Executes a Transact-SQL statement against the connection and returns the number of rows affected.
+	/// </summary>
+	NonQuery,
+
+	/// <summary>
+	/// Executes the query, and returns the first column of the first row in the result set returned by the query. Additional columns or rows are ignored.
+	/// </summary>
+	Scalar,
+
+	/// <summary>
+	/// Executes the query, and returns an object that can iterate over the entire result set.
+	/// </summary>
+	ExecuteReader
+}

--- a/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Definitions/Input.cs
+++ b/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Definitions/Input.cs
@@ -32,4 +32,14 @@ public class Input
     [PasswordPropertyText]
     public string ConnectionString { get; set; }
 
+	/// <summary>
+	/// Specifies how a command string is interpreted.
+	/// Auto: ExecuteReader for SELECT-query and NonQuery for UPDATE, INSERT, or DELETE statements.
+	/// ExecuteReader: Use this operation to execute any arbitrary SQL statements in SQL Server if you want the result set to be returned.
+	/// NonQuery: Use this operation to execute any arbitrary SQL statements in SQL Server if you do not want any result set to be returned. You can use this operation to create database objects or change data in a database by executing UPDATE, INSERT, or DELETE statements. The return value of this operation is of Int32 data type, and For the UPDATE, INSERT, and DELETE statements, the return value is the number of rows affected by the SQL statement. For all other types of statements, the return value is -1.
+	/// Scalar: Use this operation to execute any arbitrary SQL statements in SQL Server to return a single value. This operation returns the value only in the first column of the first row in the result set returned by the SQL statement.
+	/// </summary>
+	/// <example>ExecuteType.ExecuteReader</example>
+	[DefaultValue(ExecuteTypes.ExecuteReader)]
+	public ExecuteTypes ExecuteType { get; set; }
 }

--- a/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Definitions/Options.cs
+++ b/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Definitions/Options.cs
@@ -6,12 +6,18 @@ namespace Frends.PostgreSQL.ExecuteQuery.Definitions;
 /// </summary>
 public class Options
 {
+	/// <summary>
+	/// (true) Throw an exception or (false) stop the Task and return result object containing Result.Success = false and Result.ErrorMessage = 'exception message'.
+	/// </summary>
+	/// <example>true</example>
+	[DefaultValue(true)]
+	public bool ThrowErrorOnFailure { get; set; }
 
-    /// <summary>
-    /// Timeout in seconds.
-    /// </summary>
-    /// <example>30</example>
-    [DefaultValue(30)]
+	/// <summary>
+	/// Timeout in seconds.
+	/// </summary>
+	/// <example>30</example>
+	[DefaultValue(30)]
     public int CommandTimeoutSeconds { get; set; }
 
     /// <summary>

--- a/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Definitions/Result.cs
+++ b/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Definitions/Result.cs
@@ -5,18 +5,42 @@
 /// </summary>
 public class Result
 {
-    /// <summary>
-    /// Result of the query.
-    /// </summary>
-    /// <example>[{ "id": 123, "Name": "Matti" }, { "id": 124, "Name": "Teppo" }]</example>
-    public dynamic QueryResult { get; private set; }
+	/// <summary>
+	/// Operation complete without errors.
+	/// </summary>
+	/// <example>true</example>
+	public bool Success { get; private set; }
 
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    internal Result(dynamic result)
-    {
-        QueryResult = result;
-    }
+	/// <summary>
+	/// Records affected.
+	/// Some statements will return -1. See documentation of Input.ExecuteType for more information.
+	/// </summary>
+	/// <example>100</example>
+	public int RecordsAffected { get; private set; }
+
+	/// <summary>
+	/// Error message.
+	/// This value is generated when an exception occurs and Options.ThrowErrorOnFailure = false.
+	/// </summary>
+	/// <example>Login failed for user 'user'.</example>
+	public string ErrorMessage { get; private set; }
+
+	/// <summary>
+	/// Query result as JToken.
+	/// </summary>
+	/// <example>
+	/// Input.ExecuteType = ExecuteReader: [{"ID": "1","FIRST_NAME": "Saija","LAST_NAME": "Saijalainen","START_DATE": ""}],
+	/// Input.ExecuteType = NonQuery: {{  "AffectedRows": -1 }},
+	/// Input.ExecuteType = Scalar: {{  "Value": 1 }}
+	/// </example>
+	public dynamic Data { get; private set; }
+
+	internal Result(bool success, int recordsAffected, string errorMessage, dynamic data)
+	{
+		Success = success;
+		RecordsAffected = recordsAffected;
+		ErrorMessage = errorMessage;
+		Data = data;
+	}
 
 }

--- a/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery.csproj
+++ b/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery/Frends.PostgreSQL.ExecuteQuery.csproj
@@ -7,7 +7,7 @@
 	<IncludeSource>true</IncludeSource>
 	<AssemblyName>Frends.PostgreSQL.ExecuteQuery</AssemblyName>
 	<RootNamespace>Frends.PostgreSQL.ExecuteQuery</RootNamespace>
-	<Version>1.1.0</Version>
+	<Version>2.0.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -29,8 +29,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Npgsql" Version="9.0.2" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
To execute an INSERT or UPDATE command with a SELECT clause, you must manually specify the execution type. In previous versions, the task searched for the "select" keyword and always executed the query as a reader query if found.

This task is also more aligned with the Frends.MicrosoftSQL task, providing a better user experience.

Updated the Npgsql package to version 9.0.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `ExecuteType` option for executing non-query commands alongside select queries.
  - Added a new test method for validating insert-select operations.

- **Improvements**
  - Enhanced error handling during query execution with new properties for success status, affected records, and error messages.
  - Updated dependencies to the latest versions.

- **Bug Fixes**
  - Addressed issues with result data access in test methods. 

- **Documentation**
  - Updated changelog and added detailed descriptions for new properties and enums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->